### PR TITLE
Validation function in the validation schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ validationScheme: {
   ATTRIBUTE_NAME: {
     options: ATTRIBUTE_OPTIONS,
     validators: [
-      { name: VALIDATOR_NAME, options: VALIDATOR_OPTIONS }
+      {
+        name: VALIDATOR_NAME,
+        validate: VALIDATE_FUNCTION,
+        options: VALIDATOR_OPTIONS
+      }
     ]
   }
 }
@@ -42,6 +46,7 @@ validationScheme: {
 * ATTRIBUTE_NAME - имя аттрибута обеъекта, оно будет передаваться в валидатор вместе с контектом.
 * MEDIATOR_OPTIONS - хеш, который миксуется в медиатор аттрибута
 * VALIDATOR_NAME - имя валидатора, по нему lookuping класс валидатора в `validators:VALIDATOR_NAME`
+* VALIDATE_FUNCTION -  функция реализующая валидацию используется вместо `name`
 * VALIDATOR_OPTIONS - хеш, который миксуется в медиатор валидатора
 
 Структура создаваемая по схеме:

--- a/addon/mixins/validation.js
+++ b/addon/mixins/validation.js
@@ -365,6 +365,7 @@ export default Ember.Mixin.create(ValidatableMixin, Ember.Evented, {
       const name = get(description, "name");
       const options = get(description, "options");
       const validate = get(description, "validate");
+      Ember.assert("Validator in the schema should contain 'name' or 'validate'", !!(name || validate));
       const validator = validate || lookupValidator(name, get(this, "container"));
       return { options, validator };
     });

--- a/addon/mixins/validation.js
+++ b/addon/mixins/validation.js
@@ -7,7 +7,7 @@ import Errors from 'ember-validation/core/errors';
 import Config from 'ember-validation/configuration';
 import { lookupValidator, lookupPreset } from 'ember-validation/utils/lookup';
 
-const { RSVP, computed, get, assert, Logger, getWithDefault, getProperties, tryInvoke } = Ember;
+const { RSVP, computed, get, assert, Logger, getWithDefault, tryInvoke } = Ember;
 
 var findMediators = function(...names) {
     assert("You should provide at least one attribute name", !Ember.isEmpty(names));
@@ -362,8 +362,10 @@ export default Ember.Mixin.create(ValidatableMixin, Ember.Evented, {
   */
   _createValidators(attribute, validation) {
     return Ember.A( get(validation, "validators") ).map((description) => {
-      const { name, options } = getProperties(description, ["name", "options"]);
-      const validator = lookupValidator(name, get(this, "container"));
+      const name = get(description, "name");
+      const options = get(description, "options");
+      const validate = get(description, "validate");
+      const validator = validate || lookupValidator(name, get(this, "container"));
       return { options, validator };
     });
   },


### PR DESCRIPTION
Added ability to declare validation function straight in the validation schema. It's helpful when you need to define custom validation on a field without the creation of a new validator.

Example:

```es6
import Ember from 'ember';
import { createError } from 'ember-validation/utils/error';

const { RSVP: { resolve, reject } } = Ember;

function validateUserName(attributeName, context) {

  // It's a user name that need to be validated
  const value = Ember.get(context, attributeName);

  // Empty field is always valid
  if (Ember.isBlank(value)) { return resolve(); }

  // The names that begin with «A» character, supplied not valid.
  if (value.substr(0, 1) !== "A") {
    return reject(createError('error-code', value, 'custom-validator'));
  }

  return resolve();
}


export default Ember.Object.extend(ValidationMixin, {
  validationScheme: {
    name: {
      validators: [
        { name: 'required' },
        { validate: validateUserName }
      ]
    }
  }
});
```