### PR TITLE
[BD-478] Исправление сброса хеша видимости ошибок формы

### DIFF
--- a/addon/mixins/component.js
+++ b/addon/mixins/component.js
@@ -151,7 +151,7 @@ export default Ember.Mixin.create(ValidationMixin, {
    */
   clearErrors() {
     this._super(...arguments);
-    this.set('visibleErrors', Ember.A());
+    this.set('visibleErrors', {});
 
     this.get('childViews').forEach(view => {
       Ember.tryInvoke(view, 'clearErrors');


### PR DESCRIPTION
Решает задачи: [BD-478](https://wheely.atlassian.net/browse/BD-478)

----

**Проблема**
Объект с примесью инстанциируется с `visibleErrors` как `Object`, но при сбросе
ошибок, почему то `visibleErrors` становится `Array`.